### PR TITLE
fix: not propagated links

### DIFF
--- a/ios/Classes/FacebookDeeplinksPlugin.m
+++ b/ios/Classes/FacebookDeeplinksPlugin.m
@@ -85,7 +85,8 @@ static id _instance;
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
-    return [self handleLink:[url absoluteString]];
+    [self handleLink:[url absoluteString]];
+    return NO;
 }
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {


### PR DESCRIPTION
Method handleLink returns "YES" (true) by default. This method was returned from application:openURL:options. Returing "YES" from application:openURL:options indicates, that the URL has been successfully handled, hence no other parties will receive that link.

In our case, two services are registered for external links - facebook_deeplinks and receive_sharing_intent. When facebook_deeplinks first received the link and returned "YES" even though it wasn't facebook deeplink, the receive_sharing_intent was not receiving it.

Ideally, handleLink should verify if that link is in fact facebook deeplink and return true only in that case.